### PR TITLE
Replace File::Slurp with Path::Tiny

### DIFF
--- a/LINUX/README.txt
+++ b/LINUX/README.txt
@@ -28,7 +28,6 @@ and these Perl modules (from CPAN):
 - DBI
 - Email::MIME
 - Email::Sender
-- File::Slurp
 - JSON
 - Linux::Inotify2
 - List::MoreUtils

--- a/dist.ini
+++ b/dist.ini
@@ -47,7 +47,6 @@ DateTime::Format::Strptime = 0
 DBI              = 0
 Email::Sender    = 0
 Email::Stuffer   = 0
-File::Slurp      = 0
 JSON             = 0
 Linux::Inotify2  = 0
 List::MoreUtils  = 0

--- a/lib/Octopussy/App/Parser.pm
+++ b/lib/Octopussy/App/Parser.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 
 use File::Basename;
-use File::Slurp;
+use Path::Tiny;
 
 use AAT::Syslog;
 use Octopussy::App;
@@ -76,7 +76,7 @@ sub Write_Logfile
         }
         elsif (!$compression)
         {
-			write_file($logfile, { append => 1 }, @{$logs});
+                       path($logfile)->append(@{$logs});
         }
         else
         {

--- a/lib/Octopussy/Plugin.pm
+++ b/lib/Octopussy/Plugin.pm
@@ -9,7 +9,7 @@ Octopussy::Plugin - Octopussy Plugin module
 use strict;
 use warnings;
 
-use File::Slurp;
+use Path::Tiny;
 use FindBin;
 
 use AAT::Syslog;
@@ -70,9 +70,10 @@ sub Init_All
 {
     my $conf = shift;
 
-    my @plugins = grep { /.+\.pm$/ } read_dir($DIR_PLUGIN_MODULES, err_mode => 'quiet');
+    my @plugins = path($DIR_PLUGIN_MODULES)->children( qr/\.pm$/ );
     foreach my $p (@plugins)
     {
+        $p = $p->basename;
         $p =~ s/\.pm$//;
         my $func = 'Octopussy::Plugin::' . $p . '::Init';
         &{$func}($conf);
@@ -133,9 +134,10 @@ sub Functions
 
 	return ()	if (! -r $dir_plugins);
 
-    my @files = grep { /.+\.xml$/ } read_dir($dir_plugins);
+    my @files = path($dir_plugins)->children( qr/\.xml$/ );
     foreach my $f (@files)
     {
+        $f = $f->basename;
         my $conf = AAT::XML::Read("$dir_plugins/$f");
         push @functions,
             {plugin => $conf->{name}, functions => $conf->{function}}


### PR DESCRIPTION
Happy Hacktoberfest,

This PR replaces File::Slurp with Path::Tiny:

https://github.com/sebthebert/Octopussy/issues/643

Update dist.ini and LINUX/README.txt

use Path::Tiny `append` rather than `spew` so as not to create new temporary files.
All tests passing.